### PR TITLE
zookeeper_conf_dir is actually a symbolic link to

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,6 @@
 - name: Install Zookeeper
   apt: name=zookeeperd state=present
 
-- name: Create conf_dir
-  file: path={{zookeeper_conf_dir}} state=directory owner=root group=root mode=755
-
 - name: Setup zoo.cfg
   template: dest="{{zookeeper_conf_dir}}/zoo.cfg" src=zoo.cfg.j2
   notify:


### PR DESCRIPTION
/etc/alternatives/zookeeper-conf/ and the newest version of
ansible (1.8.3) failed on the directory check since it is a symbolic link
to a directory. So, remove the check on for zookeeper_conf_dir and
assume the deb set it up correctly