### PR TITLE
Use the zookeeper_id if it is already known

### DIFF
--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -1,5 +1,9 @@
-{%- for url in zookeeper_hosts.split(',') -%}
-  {%- if url.split(':')[0] == ansible_fqdn or url.split(':')[0] in ansible_all_ipv4_addresses -%}
+{%- if zookeeper_id is defined -%}
+{{ zookeeper_id }}
+{%- else-%}
+  {%- for url in zookeeper_hosts.split(',') -%}
+    {%- if url.split(':')[0] == ansible_fqdn or url.split(':')[0] in ansible_all_ipv4_addresses -%}
 {{ loop.index0 }}
-  {%- endif -%}
-{%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}


### PR DESCRIPTION
Let Tim decide to merge this. This is for hlm where the hostnames are different and the ID is easily determined