### PR TITLE
Fix zookeeper autopurge functionality

### DIFF
--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -53,5 +53,7 @@ server.{{loop.index0}}={{url.split(':')[0]}}:2888:3888
 #leaderServes=yes
 
 # Autopurge every hour to avoid using lots of disk in bursts
-autopurge.purgeInterval = 1
-autopurge.snapRetainCount = 3
+# Order of the next 2 properties matters.
+# autopurge.snapRetainCount must be before autopurge.purgeInterval.
+autopurge.snapRetainCount=3
+autopurge.purgeInterval=1


### PR DESCRIPTION
Fixes problem where zookeeper files in /var/lib/zookeeper where not being purged.
This was causing the disk to fill up.

Changed the order of these 2 lines in zoo.cfg. Turns out, order matters.

autopurge.snapRetainCount=3
autopurge.purgeInterval=1

Closes-Bug: JAH-2043