### PR TITLE
Correct zookeeper IDs to start at 1 (not 0) by default

### DIFF
--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -4,7 +4,7 @@
   {%- for url in zookeeper_hosts.split(',') -%}
     {%- set url_host = url.split(':')[0] -%}
     {%- if url_host == ansible_fqdn or url_host in ansible_all_ipv4_addresses -%}
-{{ loop.index0 }}
+{{ loop.index0 + 1 }}
     {%- endif -%}
   {%- endfor -%}
 {%- endif -%}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -25,7 +25,7 @@ maxClientCnxns={{zookeeper_maxClientCnxns}}
 {% set zookeeper_hosts_list = zookeeper_hosts.split(',') %}
 
 {% for url in zookeeper_hosts_list %}
-server.{{loop.index0}}={{url.split(':')[0]}}:2888:3888
+server.{{loop.index0 + 1}}={{url.split(':')[0]}}:2888:3888
 {% endfor %}
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
By default, zookeepers are assigned IDs starting with 0.
0 is not a vaid zookeeper ID. Should be 1-255.
Corrected to start at ID 1 by default.,
