### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,10 +15,10 @@
     - restart zookeeper
 
 - name: Create log_dir
-  file: path={{zookeeper_log_dir}} state=directory owner=zookeeper group=zookeeper mode=755
+  file: path={{zookeeper_log_dir}} state=directory owner=zookeeper group=zookeeper mode=0755
 
 - name: Setup log4j
-  template: dest="{{zookeeper_conf_dir}}/log4j.properties" owner=root group=root mode=644 src=log4j.properties.j2
+  template: dest="{{zookeeper_conf_dir}}/log4j.properties" owner=root group=root mode=0644 src=log4j.properties.j2
   notify:
     - restart zookeeper
 


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
